### PR TITLE
Revert "Use function `write single register` (#24)"

### DIFF
--- a/components/dps/dps.cpp
+++ b/components/dps/dps.cpp
@@ -163,7 +163,7 @@ void Dps::write_register(uint16_t address, uint16_t value) {
   // |    |    address
   // |    function
   // addr
-  this->send(FUNCTION_WRITE_SINGLE_REGISTER, address, 0x0001, sizeof(payload), payload);
+  this->send(FUNCTION_WRITE_MULTIPLE_REGISTERS, address, 0x0001, sizeof(payload), payload);
 }
 
 void Dps::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {


### PR DESCRIPTION
It looks like the original DPS firmware doesn't like single register writes and feezes.

This reverts commit 6ab08d8deaabe3ab2c06e7986680ec6d6c76c2a1.