### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ESPHome component to monitor and control the RDTech Digital Control Power Supply
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 or ESP8266 board
 
 ## Schematics

--- a/components/dps/__init__.py
+++ b/components/dps/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(modbus.modbus_device_schema(0x01))
+    .extend(modbus.modbus_device_schema(0x01)),
 )
 
 

--- a/components/dps/__init__.py
+++ b/components/dps/__init__.py
@@ -28,7 +28,8 @@ DPS_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Dps),

--- a/components/dps/sensor.py
+++ b/components/dps/sensor.py
@@ -17,13 +17,17 @@ from esphome.const import (
 
 from . import CONF_DPS_ID, DPS_COMPONENT_SCHEMA
 
+try:
+    from esphome.const import CONF_OUTPUT_POWER
+except ImportError:
+    CONF_OUTPUT_POWER = "output_power"
+
 DEPENDENCIES = ["dps"]
 
 CODEOWNERS = ["@syssi"]
 
 CONF_OUTPUT_VOLTAGE = "output_voltage"
 CONF_OUTPUT_CURRENT = "output_current"
-CONF_OUTPUT_POWER = "output_power"
 CONF_INPUT_VOLTAGE = "input_voltage"
 CONF_VOLTAGE_SETTING = "voltage_setting"
 CONF_CURRENT_SETTING = "current_setting"

--- a/components/lazy_limiter/__init__.py
+++ b/components/lazy_limiter/__init__.py
@@ -54,7 +54,7 @@ def validate_min_max(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    cv.require_esphome_version(2024, 6, 0),
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LazyLimiter),

--- a/components/lazy_limiter/__init__.py
+++ b/components/lazy_limiter/__init__.py
@@ -54,6 +54,7 @@ def validate_min_max(config):
 
 
 CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LazyLimiter),

--- a/esp32-example-lazy-limiter.yaml
+++ b/esp32-example-lazy-limiter.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-dps"
     version: 1.5.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-dps"
     version: 1.5.0

--- a/esp8266-example-lazy-limiter.yaml
+++ b/esp8266-example-lazy-limiter.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-dps"
     version: 1.5.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-dps"
     version: 1.5.0

--- a/esp8266-fake-dps.yaml
+++ b/esp8266-fake-dps.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-dps"
     version: 1.5.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.