### PR TITLE
Explicitly initialize all pointer members to nullptr

### DIFF
--- a/components/dps/dps.h
+++ b/components/dps/dps.h
@@ -87,27 +87,27 @@ class Dps : public PollingComponent, public modbus::ModbusDevice {
  protected:
   CurrentResolution current_resolution_{DPS_CURRENT_RESOLUTION_AUTO};
 
-  binary_sensor::BinarySensor *output_binary_sensor_;
-  binary_sensor::BinarySensor *key_lock_binary_sensor_;
-  binary_sensor::BinarySensor *constant_current_mode_binary_sensor_;
+  binary_sensor::BinarySensor *output_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *key_lock_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *constant_current_mode_binary_sensor_{nullptr};
 
-  number::Number *voltage_setting_number_;
-  number::Number *current_setting_number_;
+  number::Number *voltage_setting_number_{nullptr};
+  number::Number *current_setting_number_{nullptr};
 
-  sensor::Sensor *output_voltage_sensor_;
-  sensor::Sensor *output_current_sensor_;
-  sensor::Sensor *output_power_sensor_;
-  sensor::Sensor *input_voltage_sensor_;
-  sensor::Sensor *voltage_setting_sensor_;
-  sensor::Sensor *current_setting_sensor_;
-  sensor::Sensor *backlight_brightness_sensor_;
-  sensor::Sensor *firmware_version_sensor_;
+  sensor::Sensor *output_voltage_sensor_{nullptr};
+  sensor::Sensor *output_current_sensor_{nullptr};
+  sensor::Sensor *output_power_sensor_{nullptr};
+  sensor::Sensor *input_voltage_sensor_{nullptr};
+  sensor::Sensor *voltage_setting_sensor_{nullptr};
+  sensor::Sensor *current_setting_sensor_{nullptr};
+  sensor::Sensor *backlight_brightness_sensor_{nullptr};
+  sensor::Sensor *firmware_version_sensor_{nullptr};
 
-  switch_::Switch *output_switch_;
-  switch_::Switch *key_lock_switch_;
+  switch_::Switch *output_switch_{nullptr};
+  switch_::Switch *key_lock_switch_{nullptr};
 
-  text_sensor::TextSensor *protection_status_text_sensor_;
-  text_sensor::TextSensor *device_model_text_sensor_;
+  text_sensor::TextSensor *protection_status_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_model_text_sensor_{nullptr};
 
   void on_status_data_(const std::vector<uint8_t> &data);
   void on_acknowledge_data_(const std::vector<uint8_t> &data);

--- a/components/lazy_limiter/lazy_limiter.h
+++ b/components/lazy_limiter/lazy_limiter.h
@@ -57,16 +57,16 @@ class LazyLimiter : public PollingComponent {
  protected:
   PowerDemandCalculation power_demand_calculation_{POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR};
 
-  number::Number *manual_power_demand_number_;
-  number::Number *max_power_demand_number_;
+  number::Number *manual_power_demand_number_{nullptr};
+  number::Number *max_power_demand_number_{nullptr};
 
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *power_demand_sensor_;
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *power_demand_sensor_{nullptr};
 
-  switch_::Switch *manual_mode_switch_;
-  switch_::Switch *emergency_power_off_switch_;
+  switch_::Switch *manual_mode_switch_{nullptr};
+  switch_::Switch *emergency_power_off_switch_{nullptr};
 
-  text_sensor::TextSensor *operation_mode_text_sensor_;
+  text_sensor::TextSensor *operation_mode_text_sensor_{nullptr};
 
   int16_t buffer_;
   int16_t min_power_demand_;


### PR DESCRIPTION
## Summary
- Add `{nullptr}` in-class initializer to all raw pointer members in component header files that previously had no initializer
- Aligns with ESPHome core style: every component in the ESPHome core uses `{nullptr}` for pointer members — no uninitialized pointer exists in the core codebase
- While ESPHome instantiates components via `new T()` (value-initializes to zero), explicit `{nullptr}` makes the intent unambiguous and matches the upstream convention