### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/dps/switch/__init__.py
+++ b/components/dps/switch/__init__.py
@@ -26,10 +26,10 @@ CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OUTPUT): switch.switch_schema(
             DpsSwitch, icon=ICON_OUTPUT, entity_category=ENTITY_CATEGORY_CONFIG
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_KEY_LOCK): switch.switch_schema(
             DpsSwitch, icon=ICON_KEY_LOCK, entity_category=ENTITY_CATEGORY_CONFIG
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant