### PR TITLE
Add state_class to sensor schemas

### DIFF
--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -1,7 +1,12 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, STATE_CLASS_MEASUREMENT, UNIT_WATT
+from esphome.const import (
+    DEVICE_CLASS_POWER,
+    ICON_EMPTY,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_WATT,
+)
 
 from . import CONF_LAZY_LIMITER_ID, LAZY_LIMITER_COMPONENT_SCHEMA
 

--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, UNIT_WATT
+from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, STATE_CLASS_MEASUREMENT, UNIT_WATT
 
 from . import CONF_LAZY_LIMITER_ID, LAZY_LIMITER_COMPONENT_SCHEMA
 
@@ -17,6 +17,7 @@ CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
             icon=ICON_EMPTY,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
     }
 )


### PR DESCRIPTION
Add state_class to all sensor schemas: STATE_CLASS_MEASUREMENT for instantaneous values, STATE_CLASS_TOTAL_INCREASING for monotonically increasing counters, STATE_CLASS_TOTAL for accumulators that can decrease. This enables proper long-term statistics in Home Assistant.