### PR TITLE
Replace deprecated DEVICE_CLASS_EMPTY and ICON_EMPTY with None

### DIFF
--- a/components/dps/number/__init__.py
+++ b/components/dps/number/__init__.py
@@ -8,7 +8,6 @@ from esphome.const import (
     CONF_STEP,
     CONF_UNIT_OF_MEASUREMENT,
     ENTITY_CATEGORY_CONFIG,
-    ICON_EMPTY,
     UNIT_AMPERE,
     UNIT_VOLT,
 )
@@ -34,7 +33,7 @@ DpsNumber = dps_ns.class_("DpsNumber", number.Number, cg.Component)
 DPSNUMBER_SCHEMA = (
     number.number_schema(
         DpsNumber,
-        icon=ICON_EMPTY,
+        icon=None,
         entity_category=ENTITY_CATEGORY_CONFIG,
         unit_of_measurement=UNIT_VOLT,
     )

--- a/components/dps/sensor.py
+++ b/components/dps/sensor.py
@@ -3,10 +3,8 @@ from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
-    ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_AMPERE,
     UNIT_EMPTY,
@@ -90,14 +88,14 @@ CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_PERCENT,
             icon=ICON_BACKLIGHT_BRIGHTNESS,
             accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_FIRMWARE_VERSION): sensor.sensor_schema(
             unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_EMPTY,
+            icon=None,
             accuracy_decimals=1,
-            device_class=DEVICE_CLASS_EMPTY,
+            device_class=None,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
     }

--- a/components/dps/text_sensor.py
+++ b/components/dps/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_EMPTY
+
 
 from . import CONF_DPS_ID, DPS_COMPONENT_SCHEMA
 
@@ -25,7 +25,7 @@ CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
             text_sensor.TextSensor, icon=ICON_PROTECTION_STATUS
         ),
         cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            text_sensor.TextSensor, icon=None
         ),
     }
 )

--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -3,7 +3,6 @@ from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_POWER,
-    ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
     UNIT_WATT,
 )
@@ -19,7 +18,7 @@ CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_POWER_DEMAND): sensor.sensor_schema(
             unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
+            icon=None,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
Replace deprecated `DEVICE_CLASS_EMPTY` and `ICON_EMPTY` constants with `None` and remove them from the `esphome.const` import list.

These constants are deprecated and empty/`None` is the correct replacement per the ESPHome cleanup plan.