### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -11,6 +11,7 @@ from esphome.const import (
 from . import CONF_LAZY_LIMITER_ID, LAZY_LIMITER_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["lazy_limiter"]
+CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `lazy_limiter/sensor.py` for consistency with other ESPHome components.