### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity category

### DIFF
--- a/components/dps/text_sensor.py
+++ b/components/dps/text_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import ICON_EMPTY
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC, ICON_EMPTY
 
 from . import CONF_DPS_ID, DPS_COMPONENT_SCHEMA
 
@@ -22,10 +22,11 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_PROTECTION_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_PROTECTION_STATUS
+            icon=ICON_PROTECTION_STATUS
         ),
         cv.Optional(CONF_DEVICE_MODEL): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_EMPTY
+            icon=ICON_EMPTY,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )

--- a/components/lazy_limiter/text_sensor.py
+++ b/components/lazy_limiter/text_sensor.py
@@ -19,7 +19,6 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_MODE,
         ),
     }


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `dps` and `lazy_limiter` components (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to `device_model` sensor (T2)

Follows the pattern established in `esphome-tianpower-bms`.