### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-lazy-limiter.yaml
+++ b/esp32-example-lazy-limiter.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-dps"

--- a/esp32-example-lazy-limiter.yaml
+++ b/esp32-example-lazy-limiter.yaml
@@ -76,16 +76,16 @@ lazy_limiter:
 binary_sensor:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
     constant_current_mode:
-      name: "${name} constant current mode"
+      name: "constant current mode"
 
 sensor:
   - platform: template
     id: powermeter
-    name: "${name} smartmeter instantaneous power example"
+    name: "smartmeter instantaneous power example"
     lambda: |-
       return 100.0;
     update_interval: 5s
@@ -93,7 +93,7 @@ sensor:
 #  - platform: homeassistant
 #    internal: true
 #    id: powermeter
-#    name: "${name} smartmeter instantaneous power"
+#    name: "smartmeter instantaneous power"
 #    entity_id: sensor.smartmeter_instantaneous_power
 #    filters:
 #      - throttle_average: 15s
@@ -108,21 +108,21 @@ sensor:
 
   - platform: dps
     output_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     output_power:
-      name: "${name} output power"
+      name: "output power"
     input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"
     backlight_brightness:
-      name: "${name} backlight brightness"
+      name: "backlight brightness"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
 
 text_sensor:
   - platform: lazy_limiter
@@ -131,9 +131,9 @@ text_sensor:
 
   - platform: dps
     protection_status:
-      name: "${name} protection status"
+      name: "protection status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 switch:
   - platform: lazy_limiter
@@ -146,9 +146,9 @@ switch:
 
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
 
 number:
   - platform: lazy_limiter

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -61,48 +61,48 @@ dps:
 binary_sensor:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
     constant_current_mode:
-      name: "${name} constant current mode"
+      name: "constant current mode"
 
 sensor:
   - platform: dps
     output_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     output_power:
-      name: "${name} output power"
+      name: "output power"
     input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"
     backlight_brightness:
-      name: "${name} backlight brightness"
+      name: "backlight brightness"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
 
 text_sensor:
   - platform: dps
     protection_status:
-      name: "${name} protection status"
+      name: "protection status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 switch:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
 
 number:
   - platform: dps
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-dps"

--- a/esp8266-example-lazy-limiter.yaml
+++ b/esp8266-example-lazy-limiter.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-dps"

--- a/esp8266-example-lazy-limiter.yaml
+++ b/esp8266-example-lazy-limiter.yaml
@@ -76,16 +76,16 @@ lazy_limiter:
 binary_sensor:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
     constant_current_mode:
-      name: "${name} constant current mode"
+      name: "constant current mode"
 
 sensor:
   - platform: template
     id: powermeter
-    name: "${name} smartmeter instantaneous power example"
+    name: "smartmeter instantaneous power example"
     lambda: |-
       return 100.0;
     update_interval: 5s
@@ -93,7 +93,7 @@ sensor:
 #  - platform: homeassistant
 #    internal: true
 #    id: powermeter
-#    name: "${name} smartmeter instantaneous power"
+#    name: "smartmeter instantaneous power"
 #    entity_id: sensor.smartmeter_instantaneous_power
 #    filters:
 #      - throttle_average: 15s
@@ -108,21 +108,21 @@ sensor:
 
   - platform: dps
     output_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     output_power:
-      name: "${name} output power"
+      name: "output power"
     input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"
     backlight_brightness:
-      name: "${name} backlight brightness"
+      name: "backlight brightness"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
 
 text_sensor:
   - platform: lazy_limiter
@@ -131,9 +131,9 @@ text_sensor:
 
   - platform: dps
     protection_status:
-      name: "${name} protection status"
+      name: "protection status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 switch:
   - platform: lazy_limiter
@@ -146,9 +146,9 @@ switch:
 
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
 
 number:
   - platform: lazy_limiter

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -59,48 +59,48 @@ dps:
 binary_sensor:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
     constant_current_mode:
-      name: "${name} constant current mode"
+      name: "constant current mode"
 
 sensor:
   - platform: dps
     output_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     output_power:
-      name: "${name} output power"
+      name: "output power"
     input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"
     backlight_brightness:
-      name: "${name} backlight brightness"
+      name: "backlight brightness"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
 
 text_sensor:
   - platform: dps
     protection_status:
-      name: "${name} protection status"
+      name: "protection status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 switch:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
 
 number:
   - platform: dps
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-dps"

--- a/esp8266-fake-dps.yaml
+++ b/esp8266-fake-dps.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-dps"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -66,16 +66,16 @@ lazy_limiter:
 binary_sensor:
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
     constant_current_mode:
-      name: "${name} constant current mode"
+      name: "constant current mode"
 
 sensor:
   - platform: template
     id: powermeter
-    name: "${name} smartmeter instantaneous power example"
+    name: "smartmeter instantaneous power example"
     lambda: |-
       return 100.0;
     update_interval: 5s
@@ -90,21 +90,21 @@ sensor:
 
   - platform: dps
     output_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     output_current:
-      name: "${name} output current"
+      name: "output current"
     output_power:
-      name: "${name} output power"
+      name: "output power"
     input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     voltage_setting:
-      name: "${name} voltage setting"
+      name: "voltage setting"
     current_setting:
-      name: "${name} current setting"
+      name: "current setting"
     backlight_brightness:
-      name: "${name} backlight brightness"
+      name: "backlight brightness"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
 
 text_sensor:
   - platform: lazy_limiter
@@ -113,9 +113,9 @@ text_sensor:
 
   - platform: dps
     protection_status:
-      name: "${name} protection status"
+      name: "protection status"
     device_model:
-      name: "${name} device model"
+      name: "device model"
 
 switch:
   - platform: lazy_limiter
@@ -128,9 +128,9 @@ switch:
 
   - platform: dps
     output:
-      name: "${name} output"
+      name: "output"
     key_lock:
-      name: "${name} key lock"
+      name: "key lock"
 
 number:
   - platform: lazy_limiter


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.