### PR TITLE
Refactor sensor and binary_sensor schema definitions

### DIFF
--- a/components/dps/binary_sensor.py
+++ b/components/dps/binary_sensor.py
@@ -13,28 +13,29 @@ CODEOWNERS = ["@syssi"]
 CONF_KEY_LOCK = "key_lock"
 CONF_CONSTANT_CURRENT_MODE = "constant_current_mode"
 
-BINARY_SENSORS = [
-    CONF_OUTPUT,
-    CONF_KEY_LOCK,
-    CONF_CONSTANT_CURRENT_MODE,
-]
+BINARY_SENSOR_DEFS = {
+    CONF_OUTPUT: {"icon": "mdi:power"},
+    CONF_KEY_LOCK: {
+        "icon": "mdi:play-box-lock-outline",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CONSTANT_CURRENT_MODE: {
+        "icon": "mdi:current-dc",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
 
 CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_OUTPUT): binary_sensor.binary_sensor_schema(icon="mdi:power"),
-        cv.Optional(CONF_KEY_LOCK): binary_sensor.binary_sensor_schema(
-            icon="mdi:play-box-lock-outline", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_CONSTANT_CURRENT_MODE): binary_sensor.binary_sensor_schema(
-            icon="mdi:current-dc", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_DPS_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/dps/sensor.py
+++ b/components/dps/sensor.py
@@ -36,77 +36,70 @@ CONF_FIRMWARE_VERSION = "firmware_version"
 
 ICON_BACKLIGHT_BRIGHTNESS = "mdi:brightness-6"
 
-SENSORS = [
-    CONF_OUTPUT_VOLTAGE,
-    CONF_OUTPUT_CURRENT,
-    CONF_OUTPUT_POWER,
-    CONF_INPUT_VOLTAGE,
-    CONF_VOLTAGE_SETTING,
-    CONF_CURRENT_SETTING,
-    CONF_BACKLIGHT_BRIGHTNESS,
-    CONF_FIRMWARE_VERSION,
-]
+SENSOR_DEFS = {
+    CONF_OUTPUT_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OUTPUT_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_OUTPUT_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_INPUT_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_VOLTAGE_SETTING: {
+        "unit_of_measurement": UNIT_VOLT,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CURRENT_SETTING: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_BACKLIGHT_BRIGHTNESS: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "icon": ICON_BACKLIGHT_BRIGHTNESS,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_FIRMWARE_VERSION: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
 
-# pylint: disable=too-many-function-args
 CONFIG_SCHEMA = DPS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_OUTPUT_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_OUTPUT_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_OUTPUT_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_INPUT_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_VOLTAGE_SETTING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT_SETTING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_BACKLIGHT_BRIGHTNESS): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            icon=ICON_BACKLIGHT_BRIGHTNESS,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_FIRMWARE_VERSION): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_EMPTY,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_DPS_ID])
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
Replace flat SENSORS/BINARY_SENSORS lists and manual CONFIG_SCHEMA entries with SENSOR_DEFS/BINARY_SENSOR_DEFS dicts. Reduces repetition and makes adding new entities easier.

Reference: syssi/esphome-daly-bms#85