### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/dps/dps.cpp
+++ b/components/dps/dps.cpp
@@ -12,7 +12,7 @@ static const uint8_t FUNCTION_WRITE_SINGLE_REGISTER = 0x06;
 static const uint8_t FUNCTION_WRITE_MULTIPLE_REGISTERS = 0x10;
 
 static const uint8_t PROTECTION_STATUS_SIZE = 4;
-static const char *const PROTECTION_STATUS[PROTECTION_STATUS_SIZE] = {
+static constexpr const char *const PROTECTION_STATUS[PROTECTION_STATUS_SIZE] = {
     "Normal",        // 0x00
     "Over-Voltage",  // 0x01
     "Over-Current",  // 0x02


### PR DESCRIPTION
## Summary

- Changes `static const char *const` to `static constexpr const char *const` for the `PROTECTION_STATUS` string array in `components/dps/dps.cpp`

## Why

Using `static constexpr const char *const` for string arrays ensures they are placed into the read-only segment (Flash) at compile time rather than consuming precious RAM at runtime. This matches the style used in the ESPHome core, for example in `bme68x_bsec2.cpp`, and is the recommended approach for embedded targets where RAM is a scarce resource.

Note: single-string constants like `TAG` are intentionally left unchanged, as this style change applies only to arrays.