### PR TITLE
Use ESP-IDF framework

### DIFF
--- a/esp32-example-lazy-limiter.yaml
+++ b/esp32-example-lazy-limiter.yaml
@@ -16,6 +16,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
## Summary
- Switch from Arduino to ESP-IDF framework per ESPHome 2026.1.0 deprecation warning