### PR TITLE
Add entity_category to all text sensor schemas

### DIFF
--- a/components/lazy_limiter/text_sensor.py
+++ b/components/lazy_limiter/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_LAZY_LIMITER_ID, LAZY_LIMITER_COMPONENT_SCHEMA
 
@@ -20,6 +21,7 @@ CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
             icon=ICON_OPERATION_MODE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
Text sensors were missing `entity_category=ENTITY_CATEGORY_DIAGNOSTIC`, which causes them to appear as regular state entities instead of diagnostic ones in Home Assistant.