### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/dps/dps.cpp
+++ b/components/dps/dps.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 static const char *const TAG = "dps";
 
@@ -249,5 +248,4 @@ void Dps::dump_config() {  // NOLINT(google-readability-function-size,readabilit
   LOG_TEXT_SENSOR("", "Device Model", this->device_model_text_sensor_);
 }
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/dps/dps.h
+++ b/components/dps/dps.h
@@ -8,8 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/modbus/modbus.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 enum CurrentResolution {
   DPS_CURRENT_RESOLUTION_AUTO,
@@ -118,5 +117,4 @@ class Dps : public PollingComponent, public modbus::ModbusDevice {
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
 };
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/dps/number/dps_number.cpp
+++ b/components/dps/number/dps_number.cpp
@@ -1,8 +1,7 @@
 #include "dps_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 static const char *const TAG = "dps.number";
 
@@ -17,5 +16,4 @@ void DpsNumber::control(float value) {
   this->parent_->write_register(this->holding_register_, (uint16_t) (value * resolution));
 }
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/dps/number/dps_number.h
+++ b/components/dps/number/dps_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 class Dps;
 
@@ -22,5 +21,4 @@ class DpsNumber : public number::Number, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/dps/switch/dps_switch.cpp
+++ b/components/dps/switch/dps_switch.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 static const char *const TAG = "dps.switch";
 
 void DpsSwitch::dump_config() { LOG_SWITCH("", "DPS Switch", this); }
 void DpsSwitch::write_state(bool state) { this->parent_->write_register(this->holding_register_, (uint16_t) state); }
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/dps/switch/dps_switch.h
+++ b/components/dps/switch/dps_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace dps {
+namespace esphome::dps {
 
 class Dps;
 
@@ -23,5 +22,4 @@ class DpsSwitch : public switch_::Switch, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace dps
-}  // namespace esphome
+}  // namespace esphome::dps

--- a/components/lazy_limiter/lazy_limiter.cpp
+++ b/components/lazy_limiter/lazy_limiter.cpp
@@ -1,8 +1,7 @@
 #include "lazy_limiter.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 static const char *const TAG = "lazy_limiter";
 
@@ -153,5 +152,4 @@ void LazyLimiter::publish_state_(text_sensor::TextSensor *text_sensor, const std
   text_sensor->publish_state(state);
 }
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter

--- a/components/lazy_limiter/lazy_limiter.h
+++ b/components/lazy_limiter/lazy_limiter.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 enum PowerDemandCalculation {
   POWER_DEMAND_CALCULATION_DUMB_OEM_BEHAVIOR,
@@ -87,5 +86,4 @@ class LazyLimiter : public PollingComponent {
   int16_t calculate_power_demand_oem_(int16_t consumption);
 };
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter

--- a/components/lazy_limiter/number/lazy_limiter_number.cpp
+++ b/components/lazy_limiter/number/lazy_limiter_number.cpp
@@ -1,8 +1,7 @@
 #include "lazy_limiter_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 static const char *const TAG = "lazy_limiter.number";
 
@@ -40,5 +39,4 @@ void LazyLimiterNumber::control(float value) {
 }
 void LazyLimiterNumber::dump_config() { LOG_NUMBER("", "LazyLimiter Number", this); }
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter

--- a/components/lazy_limiter/number/lazy_limiter_number.h
+++ b/components/lazy_limiter/number/lazy_limiter_number.h
@@ -5,8 +5,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 class LazyLimiter;
 
@@ -31,5 +30,4 @@ class LazyLimiterNumber : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter

--- a/components/lazy_limiter/switch/lazy_limiter_switch.cpp
+++ b/components/lazy_limiter/switch/lazy_limiter_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 static const char *const TAG = "lazy_limiter.switch";
 
@@ -54,5 +53,4 @@ void LazyLimiterSwitch::dump_config() {
 }
 void LazyLimiterSwitch::write_state(bool state) { this->publish_state(state); }
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter

--- a/components/lazy_limiter/switch/lazy_limiter_switch.h
+++ b/components/lazy_limiter/switch/lazy_limiter_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace lazy_limiter {
+namespace esphome::lazy_limiter {
 
 enum LazyLimiterSwitchRestoreMode {
   LAZY_LIMITER_SWITCH_RESTORE_DEFAULT_OFF,
@@ -30,5 +29,4 @@ class LazyLimiterSwitch : public switch_::Switch, public Component {
   LazyLimiterSwitchRestoreMode restore_mode_{LAZY_LIMITER_SWITCH_RESTORE_DEFAULT_OFF};
 };
 
-}  // namespace lazy_limiter
-}  // namespace esphome
+}  // namespace esphome::lazy_limiter


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.