### PR TITLE
Add C++ tests

### DIFF
--- a/tests/components/dps/common.h
+++ b/tests/components/dps/common.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "esphome/components/dps/dps.h"
+
+namespace esphome::dps::testing {
+
+class TestableDps : public Dps {
+ public:
+  using Dps::on_status_data_;
+};
+
+}  // namespace esphome::dps::testing

--- a/tests/components/dps/dps_test.cpp
+++ b/tests/components/dps/dps_test.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "common.h"
+#include "frames.h"
+
+namespace esphome::dps::testing {
+
+// Frame sourced from esp8266-example-faker.yaml / esp32-example-faker.yaml
+
+class DpsStatusTest : public ::testing::Test {
+ protected:
+  TestableDps dps_;
+  sensor::Sensor output_voltage_;
+  sensor::Sensor output_current_;
+  sensor::Sensor output_power_;
+  sensor::Sensor input_voltage_;
+  sensor::Sensor voltage_setting_;
+  sensor::Sensor current_setting_;
+  sensor::Sensor backlight_brightness_;
+  sensor::Sensor firmware_version_;
+  binary_sensor::BinarySensor output_;
+  binary_sensor::BinarySensor key_lock_;
+  binary_sensor::BinarySensor constant_current_mode_;
+  text_sensor::TextSensor protection_status_;
+  text_sensor::TextSensor device_model_;
+
+  void SetUp() override {
+    dps_.set_output_voltage_sensor(&output_voltage_);
+    dps_.set_output_current_sensor(&output_current_);
+    dps_.set_output_power_sensor(&output_power_);
+    dps_.set_input_voltage_sensor(&input_voltage_);
+    dps_.set_voltage_setting_sensor(&voltage_setting_);
+    dps_.set_current_setting_sensor(&current_setting_);
+    dps_.set_backlight_brightness_sensor(&backlight_brightness_);
+    dps_.set_firmware_version_sensor(&firmware_version_);
+    dps_.set_output_binary_sensor(&output_);
+    dps_.set_key_lock_binary_sensor(&key_lock_);
+    dps_.set_constant_current_mode_binary_sensor(&constant_current_mode_);
+    dps_.set_protection_status_text_sensor(&protection_status_);
+    dps_.set_device_model_text_sensor(&device_model_);
+  }
+};
+
+TEST_F(DpsStatusTest, VoltageSetting) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(voltage_setting_.state, 36.0f, 0.005f);
+}
+
+TEST_F(DpsStatusTest, CurrentSetting) {
+  dps_.on_status_data_(STATUS_FRAME);
+  // Model DPS5020 → LOW resolution (0.01)
+  EXPECT_NEAR(current_setting_.state, 10.0f, 0.005f);
+}
+
+TEST_F(DpsStatusTest, OutputVoltage) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(output_voltage_.state, 35.98f, 0.005f);
+}
+
+TEST_F(DpsStatusTest, OutputCurrent) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(output_current_.state, 2.37f, 0.005f);
+}
+
+TEST_F(DpsStatusTest, OutputPowerCalculated) {
+  // Power is calculated from voltage * current, not from the raw register
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(output_power_.state, 35.98f * 2.37f, 0.05f);
+}
+
+TEST_F(DpsStatusTest, InputVoltage) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(input_voltage_.state, 42.31f, 0.005f);
+}
+
+TEST_F(DpsStatusTest, KeyLockFalse) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_FALSE(key_lock_.state);
+}
+
+TEST_F(DpsStatusTest, ProtectionStatusNormal) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_EQ(protection_status_.state, "Normal");
+}
+
+TEST_F(DpsStatusTest, ConstantCurrentModeFalse) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_FALSE(constant_current_mode_.state);
+}
+
+TEST_F(DpsStatusTest, OutputTrue) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_TRUE(output_.state);
+}
+
+TEST_F(DpsStatusTest, BacklightBrightness) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_FLOAT_EQ(backlight_brightness_.state, 0.0f);
+}
+
+TEST_F(DpsStatusTest, DeviceModelDps5020) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_EQ(device_model_.state, "DPS5020");
+}
+
+TEST_F(DpsStatusTest, FirmwareVersion) {
+  dps_.on_status_data_(STATUS_FRAME);
+  EXPECT_NEAR(firmware_version_.state, 1.7f, 0.05f);
+}
+
+TEST_F(DpsStatusTest, NullSensorSafe) {
+  TestableDps bare;
+  EXPECT_NO_FATAL_FAILURE(bare.on_status_data_(STATUS_FRAME));
+}
+
+}  // namespace esphome::dps::testing

--- a/tests/components/dps/frames.h
+++ b/tests/components/dps/frames.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace esphome::dps::testing {
+
+// Frame sourced from esp8266-example-faker.yaml / esp32-example-faker.yaml
+// Decoded:
+//   voltage_setting = 36.00 V, current_setting = 10.00 A (LOW resolution, DPS5020)
+//   output_voltage = 35.98 V, output_current = 2.37 A, output_power = 35.98 * 2.37 = 85.27 W
+//   input_voltage = 42.31 V, key_lock = false, protection_status = "Normal"
+//   constant_current_mode = false, output = true, backlight = 0 %
+//   model = "DPS5020", firmware_version = 1.7
+const std::vector<uint8_t> STATUS_FRAME = {
+    0x0E, 0x10,  // [0-1]  voltage_setting: 3600 * 0.01 = 36.00 V
+    0x03, 0xE8,  // [2-3]  current_setting: 1000 * 0.01 = 10.00 A
+    0x0E, 0x0E,  // [4-5]  output_voltage:  3598 * 0.01 = 35.98 V
+    0x00, 0xED,  // [6-7]  output_current:   237 * 0.01 =  2.37 A
+    0x21, 0x4F,  // [8-9]  output_power (unused, calculated from V*I)
+    0x10, 0x87,  // [10-11] input_voltage: 4231 * 0.01 = 42.31 V
+    0x00, 0x00,  // [12-13] key_lock: 0 = false
+    0x00, 0x00,  // [14-15] protection_status: 0 = Normal
+    0x00, 0x00,  // [16-17] constant_current_mode: 0 = CV mode
+    0x00, 0x01,  // [18-19] output: 1 = on
+    0x00, 0x00,  // [20-21] backlight_brightness: 0 * 20 = 0 %
+    0x13, 0x9C,  // [22-23] model: 5020 = DPS5020
+    0x00, 0x11,  // [24-25] firmware_version: 17 * 0.1 = 1.7
+};
+
+}  // namespace esphome::dps::testing

--- a/tests/components/dps/test.host.yaml
+++ b/tests/components/dps/test.host.yaml
@@ -1,0 +1,11 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+modbus:
+  - id: modbus0
+    uart_id: uart_bus
+
+dps:
+  - id: test_dps
+    modbus_id: modbus0

--- a/tests/components/lazy_limiter/common.h
+++ b/tests/components/lazy_limiter/common.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "esphome/components/lazy_limiter/lazy_limiter.h"
+
+namespace esphome::lazy_limiter::testing {
+
+class TestableLazyLimiter : public LazyLimiter {
+ public:
+  using LazyLimiter::calculate_power_demand_oem_;
+  using LazyLimiter::calculate_power_demand_negative_measurements_;
+};
+
+}  // namespace esphome::lazy_limiter::testing

--- a/tests/components/lazy_limiter/lazy_limiter_test.cpp
+++ b/tests/components/lazy_limiter/lazy_limiter_test.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::lazy_limiter::testing {
+
+class LazyLimiterOemTest : public ::testing::Test {
+ protected:
+  TestableLazyLimiter limiter_;
+
+  void SetUp() override {
+    limiter_.set_max_power_demand(2000);
+    limiter_.set_min_power_demand(100);
+    limiter_.set_buffer(10);
+  }
+};
+
+TEST_F(LazyLimiterOemTest, AboveMaxPlusBuffer) {
+  // 5000 > max(2000) + buffer(10) → clamp to max
+  EXPECT_EQ(limiter_.calculate_power_demand_oem_(5000), 2000);
+}
+
+TEST_F(LazyLimiterOemTest, AboveMax) {
+  // 2001 > max(2000) → abs(buffer - max) = abs(10 - 2000) = 1990
+  EXPECT_EQ(limiter_.calculate_power_demand_oem_(2001), 1990);
+}
+
+TEST_F(LazyLimiterOemTest, AboveMin) {
+  // 500 >= min(100) → (abs(500-10) + (500-10)) / 2 = 490
+  EXPECT_EQ(limiter_.calculate_power_demand_oem_(500), 490);
+}
+
+TEST_F(LazyLimiterOemTest, AtMin) {
+  // 100 >= min(100) → (abs(100-10) + (100-10)) / 2 = 90
+  EXPECT_EQ(limiter_.calculate_power_demand_oem_(100), 90);
+}
+
+TEST_F(LazyLimiterOemTest, BelowMin) {
+  // 90 < min(100) → 0
+  EXPECT_EQ(limiter_.calculate_power_demand_oem_(90), 0);
+}
+
+class LazyLimiterNegMeasTest : public ::testing::Test {
+ protected:
+  TestableLazyLimiter limiter_;
+
+  void SetUp() override {
+    limiter_.set_max_power_demand(900);
+    limiter_.set_min_power_demand(100);
+    limiter_.set_buffer(10);
+  }
+};
+
+TEST_F(LazyLimiterNegMeasTest, AboveMax) {
+  // importing_now=1000, demand=1500 >= max(900) → 900
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(1010, 500), 900);
+}
+
+TEST_F(LazyLimiterNegMeasTest, AtMax) {
+  // importing_now=400, demand=900 >= max(900) → 900
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(410, 500), 900);
+}
+
+TEST_F(LazyLimiterNegMeasTest, AboveMin) {
+  // importing_now=300, demand=800 < max(900), 800 > min(100) → 800
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(310, 500), 800);
+}
+
+TEST_F(LazyLimiterNegMeasTest, ZeroImporting) {
+  // importing_now=-10, demand=490 < max(900), 490 > min(100) → 490... wait:
+  // importing_now = 0 - 10 = -10, demand = -10 + 500 = 490 > min(100) → 490
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(0, 500), 490);
+}
+
+TEST_F(LazyLimiterNegMeasTest, Exporting) {
+  // importing_now=-500, demand=0 < max(900), 0 > min(100)? No → 0
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(-490, 500), 0);
+}
+
+TEST_F(LazyLimiterNegMeasTest, LargeExport) {
+  // importing_now=-700, demand=-200 < max(900), -200 > min(100)? No → 0
+  EXPECT_EQ(limiter_.calculate_power_demand_negative_measurements_(-690, 500), 0);
+}
+
+}  // namespace esphome::lazy_limiter::testing

--- a/tests/components/lazy_limiter/test.host.yaml
+++ b/tests/components/lazy_limiter/test.host.yaml
@@ -1,0 +1,10 @@
+sensor:
+  - platform: template
+    id: power_sensor
+    lambda: |-
+      return 0.0;
+    update_interval: 60s
+
+lazy_limiter:
+  - id: test_lazy_limiter
+    power_id: power_sensor


### PR DESCRIPTION
## Summary

- Adds `tests/components/dps/` with host build YAML, testable subclass, frame constants, and 14 test cases
- Adds `tests/components/lazy_limiter/` with host build YAML, testable subclass, and 11 test cases
- DPS frame sourced from `esp8266-example-faker.yaml` / `esp32-example-faker.yaml` — no synthetic data
- lazy_limiter tests exercise both OEM and negative-measurements calculation strategies using boundary conditions from the inline code comments
