### PR TITLE
CI: Run all C++ unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -551,7 +551,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py dps
+          script/cpp_unit_test.py dps lazy_limiter
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0


### PR DESCRIPTION
The C++ unit tests job was only running `dps` but `tests/components` also contains `lazy_limiter`.