### PR TITLE
Introduce SENSOR_DEFS in lazy_limiter and extend schema tests

### DIFF
--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -15,22 +15,25 @@ CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 
+SENSOR_DEFS = {
+    CONF_POWER_DEMAND: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
+
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_POWER_DEMAND): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
+    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_LAZY_LIMITER_ID])
-    if CONF_POWER_DEMAND in config:
-        sens = await sensor.new_sensor(config[CONF_POWER_DEMAND])
-        cg.add(hub.set_power_demand_sensor(sens))
+    for key in SENSOR_DEFS:
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/components/lazy_limiter/sensor.py
+++ b/components/lazy_limiter/sensor.py
@@ -27,7 +27,10 @@ SENSOR_DEFS = {
 
 # pylint: disable=too-many-function-args
 CONFIG_SCHEMA = LAZY_LIMITER_COMPONENT_SCHEMA.extend(
-    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
+    {
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
+    }
 )
 
 

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -13,7 +13,7 @@ from components.dps import (  # noqa: E402
     switch,  # noqa: E402
     text_sensor,
 )
-from components.lazy_limiter import sensor as lazy_limiter_sensor  # noqa: E402
+import components.lazy_limiter.sensor as lazy_limiter_sensor  # noqa: E402
 
 
 class TestHubConstants:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -13,6 +13,7 @@ from components.dps import (  # noqa: E402
     switch,  # noqa: E402
     text_sensor,
 )
+from components.lazy_limiter import sensor as lazy_limiter_sensor  # noqa: E402
 
 
 class TestHubConstants:
@@ -21,6 +22,17 @@ class TestHubConstants:
 
     def test_conf_current_resolution_defined(self):
         assert hub.CONF_CURRENT_RESOLUTION == "current_resolution"
+
+
+class TestLazyLimiterSensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert lazy_limiter_sensor.CONF_POWER_DEMAND in lazy_limiter_sensor.SENSOR_DEFS
+        assert len(lazy_limiter_sensor.SENSOR_DEFS) == 1
+
+    def test_sensor_defs_keys_match_schema(self):
+        assert set(lazy_limiter_sensor.SENSOR_DEFS.keys()) == {
+            lazy_limiter_sensor.CONF_POWER_DEMAND
+        }
 
 
 class TestSensorDefs:


### PR DESCRIPTION
## Summary

- Replaces the inline `sensor.sensor_schema()` call in `lazy_limiter/sensor.py` with a `SENSOR_DEFS` dict that acts as the single source of truth for both `CONFIG_SCHEMA` and `to_code`
- Since both schema registration and code generation iterate over the same dict, it is structurally impossible to declare a sensor without registering it
- Adds `TestLazyLimiterSensorDefs` to `tests/test_component_schemas.py` with count and key-presence assertions

## Test plan

- [ ] `pytest tests/test_component_schemas.py` passes
- [ ] `lazy_limiter` sensor schema unchanged from user perspective (`power_demand` still optional)