### PR TITLE
Set proper Modbus send_wait_time and turnaround_time for reliable communication

### DIFF
--- a/esp32-example-lazy-limiter.yaml
+++ b/esp32-example-lazy-limiter.yaml
@@ -55,7 +55,8 @@ uart:
 modbus:
   id: modbus0
   uart_id: uart_0
-  send_wait_time: 0ms
+  send_wait_time: 400ms
+  turnaround_time: 250ms
 
 dps:
   id: dps0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -52,7 +52,8 @@ uart:
 modbus:
   id: modbus0
   uart_id: uart_0
-  send_wait_time: 0ms
+  send_wait_time: 400ms
+  turnaround_time: 250ms
 
 dps:
   id: dps0

--- a/esp8266-example-lazy-limiter.yaml
+++ b/esp8266-example-lazy-limiter.yaml
@@ -53,7 +53,8 @@ uart:
 modbus:
   id: modbus0
   uart_id: uart_0
-  send_wait_time: 0ms
+  send_wait_time: 400ms
+  turnaround_time: 250ms
 
 dps:
   id: dps0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -50,7 +50,8 @@ uart:
 modbus:
   id: modbus0
   uart_id: uart_0
-  send_wait_time: 0ms
+  send_wait_time: 400ms
+  turnaround_time: 250ms
 
 dps:
   id: dps0


### PR DESCRIPTION
## Problem

Since ESPHome 2025.8.0, the underlying ESP-IDF was upgraded from 5.3.2 to 5.4.2. This caused the UART layer to surface RS485 idle-state noise (0xFF bytes) that was previously discarded silently, resulting in continuous Modbus CRC check failures.

The `send_wait_time: 0ms` in the example configs does not give slower devices enough time to respond after the previous request.

## Fix

Set `send_wait_time: 400ms` and `turnaround_time: 250ms` in all example configs. This was confirmed as a working fix by users in issue #48.

Fixes #48